### PR TITLE
Add a fallback threshold in case there are not enough IPOs

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -19,4 +19,4 @@ jobs:
           WHAPI_API_URL: ${{ vars.WHAPI_API_URL }}
           GMP_BASE_URL: ${{ vars.GMP_BASE_URL }}
         run: |
-          python ipo-alert/alert.py -d 3 -t 25 --github-secrets
+          python ipo-alert/alert.py -d 3 -t 30 --fallback-threshold 20 --github-secrets


### PR DESCRIPTION
* Add a fallback threshold with cli, and in case there are not enough IPOs after filtering and fallback is set, fallback threshold is in place and more IPOs are added to the filtered list with lower threshold.
* Updated cron to include fallback.