### PR TITLE
Bugfix: Fix incorrect date delta computation.

### DIFF
--- a/ipo-alert/alert.py
+++ b/ipo-alert/alert.py
@@ -159,7 +159,7 @@ def get_date_delta(date_str: str) -> int:
     date_format = "%d-%b-%Y"
 
     try:
-        current_date = datetime.now()
+        current_date = datetime.now().replace(second=0, hour=0, minute=0, microsecond=0)
         close_date = datetime.strptime(f"{date_str}-{current_date.year}", date_format)
 
         diff = close_date - current_date

--- a/ipo-alert/alert.py
+++ b/ipo-alert/alert.py
@@ -1,4 +1,5 @@
 from requests import get, post
+from requests.exceptions import HTTPError
 from argparse import ArgumentParser
 from bs4 import BeautifulSoup
 from datetime import datetime
@@ -193,8 +194,13 @@ def fetch_ipo_data() -> dict:
     Returns:
         dict: IPO data
     """
-    response = get(url=CONFIG["MAIN"]["GMP_BASE_URL"])
-
+    try:
+        response = get(url=CONFIG["MAIN"]["GMP_BASE_URL"])
+    except HTTPError as e:
+        LOGGER.error("Error fetching main site!")
+        LOGGER.error(e)
+        exit -2
+    
     # the urls we get are relavtive urls, will need to append the hostname
     base_url = urlparse(CONFIG["MAIN"]["GMP_BASE_URL"])
     hostname = f"{base_url.scheme}://{base_url.netloc}"
@@ -252,7 +258,13 @@ def fetch_subscription_info(url: str) -> dict:
     # Url changes for subscriptions page from the original scrape
     url = url.replace("/gmp", "/subscription")
 
-    response = get(url)
+    try:
+        response = get(url)
+    except HTTPError as e:
+        LOGGER.error("Error fetching subscription info for %s", url)
+        LOGGER.error(e)
+        return {}
+
     html_content = response.text
     soup = BeautifulSoup(html_content, "html.parser")
     table = None


### PR DESCRIPTION
This PR fixes #31.

Issue is caused because the current date computation assumes `00:00:00` for the time segment, meaning the diff becomes negative on the same day after the day has started. We need to only consider date here.

```
>>> current_date = datetime.now()
>>> current_date
datetime.datetime(2024, 10, 23, 0, 59, 29, 754646)
>>> close_date = datetime.strptime(f"23-Oct-{current_date.year}", "%d-%b-%Y")
>>> close_date
datetime.datetime(2024, 10, 23, 0, 0)
>>> close_date - current_date
datetime.timedelta(seconds=3598, microseconds=929593)
```